### PR TITLE
Fix/persona system: implement missing custom persona deletion UI

### DIFF
--- a/.roo/specs/persona-system/design.md
+++ b/.roo/specs/persona-system/design.md
@@ -3,6 +3,9 @@
 ## 1. Overview
 This document outlines the technical design for the Persona Management System. This system will provide the core functionality for creating, managing, and switching between different AI personas. It will act as a central hub, integrating with the `settings-menu` for the user interface, the `vtuber-memory-system` for persona-specific memories, and the Live2D model loader.
 
+**Related Specs:**
+- [Settings Management Design](../settings-management/design.md) - Defines the field management patterns, validation architecture, and event system that the persona system leverages
+
 ## 2. Architecture
 The architecture will be centered around a `PersonaManager` class that handles all persona-related logic. It will be responsible for loading, saving, and managing persona data in `localStorage`. The `settings-menu` component will be updated to interact with this manager, and events will be used to communicate persona changes to the rest of the application.
 

--- a/.roo/specs/persona-system/requirements.md
+++ b/.roo/specs/persona-system/requirements.md
@@ -3,6 +3,9 @@
 ## 1. Introduction
 This document outlines the requirements for a persona management system. The goal is to allow users to create, select, and manage different AI personas, each with its own distinct personality (system prompt), appearance (Live2D model), and memory. This system will serve as a central hub for the AI's identity, integrating with the settings menu, memory system, and model loading.
 
+**Related Specs:**
+- [Settings Management](../settings-management/requirements.md) - Provides the UI framework and field management patterns that the persona system integrates with
+
 ## 2. Requirements
 
 ### 2.1. Persona Management in Settings

--- a/.roo/specs/persona-system/requirements.md
+++ b/.roo/specs/persona-system/requirements.md
@@ -29,6 +29,18 @@ This document outlines the requirements for a persona management system. The goa
 - **GIVEN** a new persona is created **THEN** it is assigned a default system prompt and Live2D model URL.
 - **GIVEN** a persona is selected **THEN** I can edit its name, system prompt, and Live2D model URL.
 
+### 2.3. Persona Deletion
+- **As a** user,
+- **I want** to delete custom personas that I no longer need,
+- **so that** I can keep my persona list organized and relevant.
+
+#### 2.3.1. Acceptance Criteria
+- **GIVEN** I am editing a custom persona **WHEN** I view the persona form **THEN** a "Delete" button is visible.
+- **GIVEN** I click the "Delete" button on a custom persona **WHEN** the confirmation appears **THEN** I can confirm or cancel the deletion.
+- **GIVEN** I confirm deletion of a custom persona **THEN** the persona is permanently removed from the system and I am returned to the persona list.
+- **GIVEN** I try to delete a default persona (VTuber or Assistant) **THEN** no delete button is shown and the action is prevented.
+- **GIVEN** I delete the currently active persona **THEN** the system automatically switches to the default VTuber persona.
+
 ### 2.3. Persona Data Persistence
 - **As a** user,
 - **I want** my created personas to be saved,

--- a/.roo/specs/persona-system/tasks.md
+++ b/.roo/specs/persona-system/tasks.md
@@ -3,6 +3,9 @@
 ## 🎯 **Current Priority**
 Implement the persona management system, allowing users to create, select, and manage different AI personas.
 
+**Related Specs:**
+- [Settings Management Tasks](../settings-management/tasks.md) - Contains the foundational settings menu implementation that this persona system builds upon
+
 - [x] 1. **Create `PersonaManager` Class**: Implement the `PersonaManager` class to handle all persona-related logic, including loading from and saving to `localStorage`.
   - Requirements: 2.3.1
   - Design: 3.1, 4.1, 5

--- a/.roo/specs/persona-system/tasks.md
+++ b/.roo/specs/persona-system/tasks.md
@@ -39,3 +39,9 @@ Implement the persona management system, allowing users to create, select, and m
 - [x] 7. **Refactor Live2D Model Loading**: Refactor any remaining direct `localStorage` access for the Live2D model URL to use the `PersonaManager`.
   - Requirements: 2.4.1
   - Design: 3.2
+
+- [x] 8. **Implement Persona Deletion UI**: Add delete functionality to the persona management interface.
+  - Add delete button to persona editing form for custom personas only
+  - Implement confirmation dialog for persona deletion
+  - Handle active persona deletion by switching to default VTuber persona
+  - Requirements: 2.3.1

--- a/.roo/specs/settings-management/design.md
+++ b/.roo/specs/settings-management/design.md
@@ -3,6 +3,9 @@
 ## 1. Overview
 This document outlines the technical design for the application's settings and API key management. The system ensures that the application is always functional, prompting the user for an API key only when an action requiring it is performed. The key is validated, persisted in local storage, and can be managed through a dedicated settings menu.
 
+**Related Specs:**
+- [Persona System Design](../persona-system/design.md) - Extends this settings architecture to support persona management, leveraging the field validation patterns and event system defined here
+
 ## 2. Architecture
 The settings management will be handled by a dedicated `settings-menu` component. The main application component (`gdm-live-audio`) will control its visibility and respond to events, such as when a new API key is saved. A `ToastNotification` component will be used to display user prompts.
 

--- a/.roo/specs/settings-management/requirements.md
+++ b/.roo/specs/settings-management/requirements.md
@@ -3,6 +3,9 @@
 ## 1. Introduction
 This document outlines the requirements for the application's settings management, focusing on API key configuration. The goal is to provide a seamless user experience where users are guided to configure their API key when necessary, can manage it through a dedicated settings menu, and have their key persist across sessions.
 
+**Related Specs:**
+- [Persona System](../persona-system/requirements.md) - Builds upon this settings framework to provide persona management functionality within the settings menu
+
 ## 2. Requirements
 
 ### 2.1. Direct Main UI Landing with API Key Validation

--- a/.roo/specs/settings-management/tasks.md
+++ b/.roo/specs/settings-management/tasks.md
@@ -3,6 +3,9 @@
 ## 🎯 **Current Priority**
 Implement the settings menu and API key management functionality.
 
+**Related Specs:**
+- [Persona System Tasks](../persona-system/tasks.md) - Builds upon the settings menu foundation implemented here to add persona management capabilities
+
 - [x] 1. Implement Settings Menu UI: Create the `settings-menu.ts` component with an API key input field, validation, and paste/get key buttons.
   - Requirements: 2.3.1, 2.4.1, 2.5.1
 

--- a/settings-menu.ts
+++ b/settings-menu.ts
@@ -1122,13 +1122,13 @@ export class SettingsMenu extends LitElement {
 
       // If we deleted the active persona, switch to default VTuber persona
       if (wasActive) {
-        const vtuberPersona = this.personaManager
+        const defaultPersona = this.personaManager
           .getPersonas()
-          .find((p) => p.name === "VTuber");
-        if (vtuberPersona) {
+          .find((p) => p.isDefault);
+        if (defaultPersona) {
           // Use setTimeout to ensure proper sequencing and prevent race conditions
           setTimeout(() => {
-            this.personaManager.setActivePersona(vtuberPersona.id);
+            this.personaManager.setActivePersona(defaultPersona.id);
             // The persona-changed event will trigger the main app update
             // We just need to reload our local state
             this._loadPersonas();

--- a/settings-menu.ts
+++ b/settings-menu.ts
@@ -148,6 +148,9 @@ export class SettingsMenu extends LitElement {
   @state()
   private _editingPersona: Persona | null = null;
 
+  @state()
+  private _showDeleteConfirmation: boolean = false;
+
   private personaManager: PersonaManager;
 
   constructor() {
@@ -897,10 +900,72 @@ export class SettingsMenu extends LitElement {
     .persona-form-buttons {
       display: flex;
       gap: 1rem;
-      justify-content: flex-end;
+      justify-content: space-between;
       padding: 1rem 0;
       border-top: 1px solid var(--cp-surface-border);
       margin-top: 1rem;
+    }
+
+    .persona-form-buttons .right-buttons {
+      display: flex;
+      gap: 1rem;
+    }
+
+    button.danger {
+      background: linear-gradient(135deg, var(--cp-red), #ff6b7a);
+      border-color: var(--cp-red);
+      color: white;
+      font-weight: 600;
+    }
+
+    button.danger:hover {
+      box-shadow: 0 4px 16px rgba(255, 71, 87, 0.3);
+    }
+
+    /* Confirmation Dialog Styles */
+    .confirmation-dialog {
+      position: fixed;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      background: rgba(0, 0, 0, 0.7);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      z-index: 1000;
+      backdrop-filter: blur(4px);
+    }
+
+    .confirmation-content {
+      background: var(--cp-surface);
+      color: var(--cp-text);
+      padding: 2rem;
+      border-radius: 12px;
+      border: 1px solid var(--cp-surface-border);
+      box-shadow: var(--cp-glow-purple);
+      max-width: 400px;
+      width: 90vw;
+      text-align: center;
+    }
+
+    .confirmation-title {
+      font-size: 1.2rem;
+      font-weight: 600;
+      margin-bottom: 1rem;
+      color: var(--cp-red);
+    }
+
+    .confirmation-message {
+      margin-bottom: 2rem;
+      line-height: 1.5;
+      color: var(--cp-muted);
+    }
+
+    .confirmation-buttons {
+      display: flex;
+      gap: 1rem;
+      justify-content: center;
     }
 
     /* Accessibility Enhancements */
@@ -997,8 +1062,22 @@ export class SettingsMenu extends LitElement {
           </button>
         </div>
         <div class="persona-form-buttons">
-          <button @click=${this._cancelPersonaEdit}>Cancel</button>
-          <button class="primary" @click=${this._onSavePersona}>Save</button>
+          ${
+            !this._editingPersona.isDefault
+              ? html`
+            <button class="danger" @click=${this._onDeletePersona}>
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" style="margin-right: 0.5rem;">
+                <path d="M19,4H15.5L14.5,3H9.5L8.5,4H5V6H19M6,19A2,2 0 0,0 8,21H16A2,2 0 0,0 18,19V7H6V19Z"/>
+              </svg>
+              Delete
+            </button>
+          `
+              : ""
+          }
+          <div class="right-buttons">
+            <button @click=${this._cancelPersonaEdit}>Cancel</button>
+            <button class="primary" @click=${this._onSavePersona}>Save</button>
+          </div>
         </div>
       </div>
     `;
@@ -1022,6 +1101,76 @@ export class SettingsMenu extends LitElement {
   private _cancelPersonaEdit() {
     this._editingPersona = null;
     this.requestUpdate();
+  }
+
+  private _onDeletePersona() {
+    this._showDeleteConfirmation = true;
+    this.requestUpdate();
+  }
+
+  private _confirmDeletePersona() {
+    if (this._editingPersona && !this._editingPersona.isDefault) {
+      const wasActive = this._activePersona?.id === this._editingPersona.id;
+      const personaToDelete = this._editingPersona;
+
+      // Close dialogs first to prevent UI flickering
+      this._editingPersona = null;
+      this._showDeleteConfirmation = false;
+
+      // Delete the persona
+      this.personaManager.deletePersona(personaToDelete.id);
+
+      // If we deleted the active persona, switch to default VTuber persona
+      if (wasActive) {
+        const vtuberPersona = this.personaManager
+          .getPersonas()
+          .find((p) => p.name === "VTuber");
+        if (vtuberPersona) {
+          // Use setTimeout to ensure proper sequencing and prevent race conditions
+          setTimeout(() => {
+            this.personaManager.setActivePersona(vtuberPersona.id);
+            // The persona-changed event will trigger the main app update
+            // We just need to reload our local state
+            this._loadPersonas();
+            this.requestUpdate();
+          }, 50);
+          return; // Don't call requestUpdate immediately
+        }
+      }
+
+      // If we didn't delete the active persona, just reload the list
+      this._loadPersonas();
+      this.requestUpdate();
+    }
+  }
+
+  private _cancelDeletePersona() {
+    this._showDeleteConfirmation = false;
+    this.requestUpdate();
+  }
+
+  private _renderDeleteConfirmation() {
+    if (!this._editingPersona) return html``;
+
+    return html`
+      <div class="confirmation-dialog" @click=${this._cancelDeletePersona}>
+        <div class="confirmation-content" @click=${(e: Event) => e.stopPropagation()}>
+          <div class="confirmation-title">Delete Persona</div>
+          <div class="confirmation-message">
+            Are you sure you want to delete "${this._editingPersona.name}"? This action cannot be undone.
+            ${
+              this._activePersona?.id === this._editingPersona.id
+                ? html`<br><br><strong>Note:</strong> This is your currently active persona. You will be switched to the default VTuber persona.`
+                : ""
+            }
+          </div>
+          <div class="confirmation-buttons">
+            <button @click=${this._cancelDeletePersona}>Cancel</button>
+            <button class="danger" @click=${this._confirmDeletePersona}>Delete</button>
+          </div>
+        </div>
+      </div>
+    `;
   }
 
   private _onSaveTheme() {
@@ -1252,6 +1401,8 @@ export class SettingsMenu extends LitElement {
           ${this._renderThemeSelection()}
 
       </div>
+      
+      ${this._showDeleteConfirmation ? this._renderDeleteConfirmation() : ""}
     `;
   }
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Implements UI for deleting custom personas with confirmation dialog, prevents deletion of default personas, and handles active persona deletion by switching to default VTuber persona.
> 
>   - **Persona Deletion UI**:
>     - Adds delete button to persona editing form in `settings-menu.ts` for custom personas only.
>     - Implements confirmation dialog for persona deletion.
>     - Handles active persona deletion by switching to default VTuber persona.
>   - **Behavior**:
>     - Prevents deletion of default personas (VTuber or Assistant).
>     - Ensures system switches to default VTuber persona if active persona is deleted.
>   - **Code Changes**:
>     - Updates `live2d-model.ts` to handle URL changes more robustly, including a delay for cleanup and preventing race conditions.
>     - Adds `_showDeleteConfirmation` state and related methods in `settings-menu.ts` to manage delete confirmation dialog.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=daoch4n%2Fgemini-live-2d&utm_source=github&utm_medium=referral)<sup> for 45fc4996246d26306b717aed10312f3695093d01. You can [customize](https://app.ellipsis.dev/daoch4n/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->