### PR TITLE
feat(energy): initial greeting; chat energy ui

### DIFF
--- a/.roo/specs/dual-input-mode/requirements.md
+++ b/.roo/specs/dual-input-mode/requirements.md
@@ -57,8 +57,8 @@ This document outlines the requirements for a dual-input mode that simulates a r
 
 #### 2.4.1. Acceptance Criteria
 - **WHEN** no call is active **THEN** only the chat window (texting interface) is visible
-- **WHEN** a call becomes active **THEN** the chat window is hidden and the call transcript window appears
-- **WHEN** a call ends **THEN** the call transcript window is hidden and the chat window reappears
+- **WHEN** a call becomes active **THEN** the entire tabbed interface (including the chat window and tabs) is hidden and the call transcript window appears
+- **WHEN** a call ends **THEN** the call transcript window is hidden and the tabbed interface reappears
 - **WHEN** the call transcript window is visible **THEN** it displays real-time transcription of the voice conversation
 
 ### 2.8. Smart Auto-scroll Transcript Behavior
@@ -132,6 +132,7 @@ This document outlines the requirements for a dual-input mode that simulates a r
 - **WHEN** a call is active **THEN** the Live2D model area remains unoccupied by transcript windows for better visibility
 - **WHEN** a call is active **THEN** the call transcript does not extend into the space under the Live2D model
 - **WHEN** switching between texting and calling modes **THEN** both transcript windows maintain consistent dimensions and positioning
+- **WHEN** a call is active **THEN** call progress/status UI (e.g., connecting/connected/active banners) must not overlap the center Live2D area and should appear in the right-side call transcript header instead.
 
 ### 2.10. Tabbed Chat Interface
 - **As a** user,

--- a/.roo/specs/energy-bar-system/design.md
+++ b/.roo/specs/energy-bar-system/design.md
@@ -74,13 +74,13 @@ graph TD
     *   `updateEnergyLevel(level: number): void`
 *   **Visibility:** Only visible during active calls within the call controls area.
 
-#### 3. TTS Energy Indicator  
+#### 3. TTS Energy Indicator
 *   **Responsibility:** Displays the battery-style icon within the chat interface header. Shows TTS energy levels (0-2) with appropriate colors and animations.
 *   **Interface:**
     *   `updateEnergyLevel(level: number): void`
 *   **Visibility:** Always visible in the chat header when the chat interface is displayed.
 
-#### 3. Persona Service (Existing, Modified)
+#### 4. Persona Service (Existing, Modified)
 *   **Responsibility:** Selects and provides the appropriate conversational prompt based on the current energy level, selected persona, and interaction mode.
 *   **Interface (New/Modified):**
     *   `getPromptForEnergyLevel(level: number, persona: string, mode: 'sts' | 'tts'): string`

--- a/.roo/specs/energy-bar-system/tasks.md
+++ b/.roo/specs/energy-bar-system/tasks.md
@@ -1,30 +1,41 @@
 # Implementation Plan: Energy Bar System (Dual-Mode)
 
-- [x] 1. **Implement the Dual-Mode EnergyBarService**
+- [x] 1. **Implement the Dual-Mode EnergyBarService with TTS Fallback Model**
   - [x] 1.1. Create a new file for the `EnergyBarService`.
-  - [x] 1.2. Implement state for `stsEnergyLevel` and `ttsEnergyLevel`, initialized to 3. (Ref: Req 2.1.1)
-  - [x] 1.3. Implement `stsModelTier` and `ttsModelTier` state and the mappings from energy level to model names for both modes. (Ref: Design "Data Models")
+  - [x] 1.2. Implement state for `stsEnergyLevel` (initialized to 3) and `ttsEnergyLevel` (initialized to 2). (Ref: Req 2.1.1)
+  - [x] 1.3. Implement `stsModelTier` and `ttsModelTier` state and the mappings from energy level to model names for both modes, with TTS fallback model at level 1. (Ref: Design "Data Models")
   - [x] 1.4. Implement the `getCurrentEnergyLevel(mode)` method. (Ref: Design "Components and Interfaces")
   - [x] 1.5. Implement the `handleRateLimitError(mode)` method to decrement the energy level for the specified mode. (Ref: Req 2.1.2)
-  - [x] 1.6. Implement the `resetEnergyLevel(reason, mode)` method to set the energy level to 3 for the specified mode. (Ref: Req 2.1.3)
+  - [x] 1.6. Implement the `resetEnergyLevel(reason, mode)` method to set the energy level to maximum for the specified mode (3 for STS, 2 for TTS). (Ref: Req 2.1.3)
   - [x] 1.7. Integrate with the `DebugLoggingSystem` to log all state changes with the correct mode. (Ref: Req 2.1.4)
+  - [x] 1.8. Update TTS model mapping to use `gemini-2.0-flash-live-001` as fallback at energy level 1. (Ref: Req 2.1.2)
 
 - [x] 2. **Integrate EnergyBarService with the Application**
   - [x] 2.1. Modify the `Rate Limit Detector` to call `EnergyBarService.handleRateLimitError()` with the correct mode (`sts` or `tts`) upon detecting a rate limit error.
   - [x] 2.2. Modify the `STS Session Connector` to call `EnergyBarService.resetEnergyLevel()` for the `sts` mode on a new session connection.
 
-- [x] 3. **Create the Energy Bar UI Component (STS Only)**
-  - [x] 3.1. Create a new UI component for the Energy Bar. (Ref: Req 2.2.1)
-  - [x] 3.2. Implement the visual representation of the battery icon with 3 bars.
-  - [x] 3.3. Implement logic to update the number of filled bars based on the `stsEnergyLevel` from the application state. (Ref: Req 2.2.2)
-  - [x] 3.4. Implement logic to change the icon's color based on the `stsEnergyLevel`. (Ref: Req 2.2.2)
-  - [x] 3.5. Ensure the component **does not** react to changes in `ttsEnergyLevel`.
-  - [x] 3.6. Implement animations for state changes (draining and filling).
+- [x] 3. **Create Dual-Session Energy Indicators**
+  - [x] 3.1. ✅ STS Energy Indicator is already implemented and functioning perfectly in call header area. (Ref: Req 2.2.1)
+  - [x] 3.2. Create TTS Energy Indicator component for chat interface. (Ref: Req 2.2.2)
+    - [x] Implement battery-style icon with 3 levels (0-2) for TTS mode
+    - [x] Add appropriate colors and animations for state changes
+    - [x] Ensure visibility in chat header when chat interface is displayed
+  - [x] 3.3. Implement independent indicator updates. (Ref: Req 2.2.3)
+    - [x] STS indicator already responds correctly to STS energy changes
+    - [x] TTS indicator only responds to TTS energy changes
+    - [x] Remove old main battery bar component from status bar
 
 - [x] 4. **Update the Persona Service (Mode-Aware)**
   - [x] 4.1. Modify the `Persona Service` to be aware of the `currentEnergyLevel` and `mode`.
   - [x] 4.2. Implement the `getPromptForEnergyLevel(level, persona, mode)` method to return the correct persona-specific prompt for each energy level (2, 1, 0) for the **STS mode**. (Ref: Req 2.3.1)
   - [x] 4.3. Ensure no special prompt is returned when the energy level is 3.
+  - [x] 4.4. Add TTS prompts for all energy levels (2, 1, 0) with persona-specific greetings and degraded state messages. (Ref: Req 2.3.2)
+
+- [x] 4.5. **Implement TTS Prompt Injection into Chat Window**
+  - [x] 4.5.1. Modify the energy level change handler to inject ALL TTS prompts directly into the chat window as model messages.
+  - [x] 4.5.2. Add `_appendTextMessage` method to inject messages directly into the text transcript.
+  - [x] 4.5.3. Ensure TTS level 2 greetings encourage user interaction and feel welcoming. (Ref: Req 2.3.2)
+  - [x] 4.5.4. Ensure TTS level 1 and 0 prompts provide clear feedback about energy state changes in the chat. (Ref: Req 2.3.2)
 
 - [x] 5. **Implement Testing Strategy (Dual-Mode)**
   - [x] 5.1. Create unit tests for the `EnergyBarService` to verify state transitions and logging for both modes independently.

--- a/.roo/specs/toast-component-redesign/tasks.md
+++ b/.roo/specs/toast-component-redesign/tasks.md
@@ -1,7 +1,7 @@
 # Implementation Plan: Toast Component Redesign
 
-## 🎯 **Current Priority**
-Redesign the toast notification component to fully integrate with the theme engine system, providing enhanced visual consistency and persona-aware styling.
+## 🎯 Current Priority
+Redesign the toast notification component to fully integrate with the theme engine system, providing enhanced visual consistency and persona-aware styling. Also unify all inline and global toasts under a single atomic component and remove legacy inline status blocks/timers.
 
 - [ ] 1. **Analyze Current Implementation and Dependencies**
   - [ ] 1.1. Audit current toast-notification.ts component structure and API

--- a/.roo/steering/structure.md
+++ b/.roo/steering/structure.md
@@ -44,3 +44,50 @@
 - Event-driven communication between components
 - Reactive properties for state management
 - Shadow DOM for component encapsulation
+
+## UI Layout & Mode Behavior
+
+- Grid layout: three columns `400px 1fr 400px`.
+  - Left panel (400px): tabbed interface containing Chat or Call History.
+  - Center (1fr): Live2D model area; must remain unobstructed at all times.
+  - Right panel (400px): Call transcript area, visible only during a call.
+
+### Left Panel (Tabbed Interface)
+- Element: `.main-container` (contains `<tab-view>` and either `<chat-view>` or `<call-history-view>`)
+- Behavior:
+  - Default mode is texting. The left panel is visible and shows the tab bar and selected tab contents.
+  - When a call starts (`activeMode === "calling"`), the left panel fades out (opacity/visibility transition ~200ms) using a CSS class: `.main-container.hidden`.
+  - The grid columns remain fixed; we do NOT collapse the left column so the right panel stays on the right.
+- Tabs (`<tab-view>`):
+  - Tabs: Chat, Call History.
+  - `visible` boolean attribute used to hide the tab bar when calling.
+  - Chat view reuses the same auto-scroll + scroll-to-bottom logic as call transcript.
+
+### Center Area (Live2D)
+- Element: `<live2d-gate>` behind UI (z-index below UI overlay) to keep the model unobstructed.
+- Status toast (`#status`) is hidden while calling; call progress appears in the right panel header.
+
+### Right Panel (Call Transcript)
+- Element: `<call-transcript>` with `visible` boolean attribute to toggle view.
+- Behavior:
+  - Visible only when `activeMode === "calling"`.
+  - Fades in/out with opacity/visibility transition (~200ms) and pointer-events disabled while hidden.
+  - Header displays call progress via `callState`: "connecting" | "active" | "ending" | "idle".
+  - Call progress/status UI must appear here (never over the center Live2D area).
+
+### Mode Switching Flow
+- Start call:
+  - `activeMode = "calling"`, `callState = "connecting"` → left panel fades out, right transcript fades in.
+  - On media ready: `callState = "active"`. Bottom-center status toast is suppressed during the call.
+- End call:
+  - `callState = "ending"` then `"idle"`; `activeMode = "texting"` → right fades out, left fades back in.
+  - Call transcript is cleared and summarized; summary is added to Call History.
+
+### Scroll & Controls
+- Both Chat and Call Transcript use `transcript-auto-scroll` with `scroll-state-changed` events.
+- `controls-panel` mirrors scroll-to-bottom buttons for both sides; buttons show only when appropriate.
+
+### Key Components & State
+- Components: `chat-view`, `call-transcript`, `tab-view`, `call-history-view`, `controls-panel`, `toast-notification`.
+- State (in `gdm-live-audio`): `activeMode`, `isCallActive`, `callState`, `activeTab`, `textTranscript`, `callTranscript`, `textSession`, `callSession`.
+- Session managers: `TextSessionManager`, `CallSessionManager` handle lifecycle and audio streaming.

--- a/call-transcript.ts
+++ b/call-transcript.ts
@@ -1,8 +1,8 @@
 import { css, html, LitElement } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
-import "./energy-bar.js";
 import { createComponentLogger } from "./src/debug-logger";
 import { defaultAutoScroll } from "./transcript-auto-scroll";
+import "./energy-bar.js";
 
 const logger = createComponentLogger("call-transcript");
 

--- a/call-transcript.ts
+++ b/call-transcript.ts
@@ -1,8 +1,8 @@
 import { css, html, LitElement } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
+import "./energy-bar.js";
 import { createComponentLogger } from "./src/debug-logger";
 import { defaultAutoScroll } from "./transcript-auto-scroll";
-import "./energy-bar.js";
 
 const logger = createComponentLogger("call-transcript");
 

--- a/call-transcript.ts
+++ b/call-transcript.ts
@@ -1,7 +1,6 @@
 import { css, html, LitElement } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import { createComponentLogger } from "./src/debug-logger";
-import "./energy-bar";
 import { defaultAutoScroll } from "./transcript-auto-scroll";
 
 const logger = createComponentLogger("call-transcript");
@@ -306,7 +305,6 @@ export class CallTranscript extends LitElement {
   render() {
     return html`
       <div class="header">
-        <energy-bar></energy-bar>
         <div class="header-content">
           <div class="call-indicator"></div>
           <span>Call in Progress</span>

--- a/call-transcript.ts
+++ b/call-transcript.ts
@@ -2,6 +2,7 @@ import { css, html, LitElement } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import { createComponentLogger } from "./src/debug-logger";
 import { defaultAutoScroll } from "./transcript-auto-scroll";
+import "./energy-bar.js";
 
 const logger = createComponentLogger("call-transcript");
 
@@ -21,6 +22,9 @@ export class CallTranscript extends LitElement {
 
   @property({ type: String })
   activePersonaName: string = "VTuber";
+
+  @property({ type: String })
+  callState: "idle" | "connecting" | "active" | "ending" = "idle";
 
   @state()
   private newMessageCount = 0;
@@ -43,12 +47,14 @@ export class CallTranscript extends LitElement {
       color: var(--cp-text);
       opacity: 0;
       visibility: hidden;
-      transition: opacity 0.3s ease, visibility 0.3s ease;
+      pointer-events: none;
+      transition: opacity 200ms ease, visibility 200ms ease;
     }
 
     :host([visible]) {
       opacity: 1;
       visibility: visible;
+      pointer-events: auto;
     }
 
     .header {
@@ -69,6 +75,12 @@ export class CallTranscript extends LitElement {
       display: flex;
       align-items: center;
       gap: 8px;
+    }
+
+    .header-controls {
+      display: flex;
+      align-items: center;
+      gap: 12px;
     }
 
 
@@ -307,13 +319,24 @@ export class CallTranscript extends LitElement {
       <div class="header">
         <div class="header-content">
           <div class="call-indicator"></div>
-          <span>Call in Progress</span>
+          <span>
+            ${this.callState === "connecting"
+              ? "Connecting..."
+              : this.callState === "active"
+              ? "Call in Progress"
+              : this.callState === "ending"
+              ? "Ending call..."
+              : "Call"}
+          </span>
         </div>
-        <button class="reset-button" @click=${this._resetCall} title="Clear call history">
-          <svg xmlns="http://www.w3.org/2000/svg" height="16px" viewBox="0 -960 960 960" width="16px" fill="currentColor">
-            <path d="M480-160q-134 0-227-93t-93-227q0-134 93-227t227-93q69 0 132 28.5T720-690v-110h80v280H520v-80h168q-32-56-87.5-88T480-720q-100 0-170 70t-70 170q0 100 70 170t170 70q77 0 139-44t87-116h84q-28 106-114 173t-196 67Z"/>
-          </svg>
-        </button>
+        <div class="header-controls">
+          <button class="reset-button" @click=${this._resetCall} title="Clear call history">
+            <svg xmlns="http://www.w3.org/2000/svg" height="16px" viewBox="0 -960 960 960" width="16px" fill="currentColor">
+              <path d="M480-160q-134 0-227-93t-93-227q0-134 93-227t227-93q69 0 132 28.5T720-690v-110h80v280H520v-80h168q-32-56-87.5-88T480-720q-100 0-170 70t-70 170q0 100 70 170t170 70q77 0 139-44t87-116h84q-28 106-114 173t-196 67Z"/>
+            </svg>
+          </button>
+          <energy-bar></energy-bar>
+        </div>
       </div>
       <div class="transcript">
         ${

--- a/chat-view.ts
+++ b/chat-view.ts
@@ -452,6 +452,21 @@ export class ChatView extends LitElement {
 
   render() {
     return html`
+      <div class="header">
+        <div class="header-title">
+          <svg class="message-icon" xmlns="http://www.w3.org/2000/svg" height="16px" viewBox="0 -960 960 960" width="16px" fill="currentColor">
+            <path d="M240-400h320v-80H240v80Zm0-120h480v-80H240v80Zm0-120h480v-80H240v80ZM80-80v-720q0-33 23.5-56.5T160-880h640q33 0 56.5 23.5T880-800v480q0 33-23.5 56.5T800-240H240L80-80Z"/>
+          </svg>
+          <span>Chat</span>
+        </div>
+        <div class="header-actions">
+          <button class="reset-button" @click=${this._resetText} title="Clear conversation">
+            <svg xmlns="http://www.w3.org/2000/svg" height="16px" viewBox="0 -960 960 960" width="16px" fill="currentColor">
+              <path d="M280-120q-33 0-56.5-23.5T200-200v-520h-40v-80h200v-40h240v40h200v80h-40v520q0 33-23.5 56.5T680-120H280Z"/>
+            </svg>
+          </button>
+        </div>
+      </div>
       <div class="transcript-container">
         <div class="transcript">
           ${

--- a/chat-view.ts
+++ b/chat-view.ts
@@ -27,6 +27,9 @@ export class ChatView extends LitElement {
   @state()
   private newMessageCount = 0;
 
+  @state()
+  private isChatActive = false;
+
   private lastSeenMessageCount = 0;
   private textareaRef: HTMLTextAreaElement | null = null;
 
@@ -311,6 +314,28 @@ export class ChatView extends LitElement {
     log.debug("Input value changed");
   }
 
+  private _handleFocus() {
+    this.isChatActive = true;
+    this._dispatchChatActiveChanged();
+  }
+
+  private _handleBlur() {
+    this.isChatActive = false;
+    this._dispatchChatActiveChanged();
+  }
+
+  private _dispatchChatActiveChanged() {
+    const detail = { isChatActive: this.isChatActive };
+    log.debug("Chat active changed", detail);
+    this.dispatchEvent(
+      new CustomEvent("chat-active-changed", {
+        detail,
+        bubbles: true,
+        composed: true,
+      }),
+    );
+  }
+
   private _resizeTextarea(textarea: HTMLTextAreaElement) {
     // Reset height to recalculate
     textarea.style.height = "auto";
@@ -497,9 +522,11 @@ export class ChatView extends LitElement {
         </div>
       </div>
       <div class="input-area">
-        <textarea 
-          .value=${this.inputValue} 
-          @input=${this._handleInput} 
+        <textarea
+          .value=${this.inputValue}
+          @input=${this._handleInput}
+          @focus=${this._handleFocus}
+          @blur=${this._handleBlur}
           @keydown=${(e: KeyboardEvent) => {
             if (e.key === "Enter" && !e.shiftKey) {
               e.preventDefault();

--- a/controls-panel.ts
+++ b/controls-panel.ts
@@ -8,6 +8,9 @@ export class ControlsPanel extends LitElement {
   isCallActive = false;
 
   @property({ type: Boolean })
+  isChatActive = false;
+
+  @property({ type: Boolean })
   showCallScrollToBottom = false;
 
   @property({ type: Number })
@@ -168,7 +171,7 @@ export class ControlsPanel extends LitElement {
       </div>
 
       <div class="right-controls">
-        <tts-energy-bar></tts-energy-bar>
+        ${!this.isChatActive ? html`<tts-energy-bar></tts-energy-bar>` : ""}
         <button
           id="settingsButton"
           @click=${this._toggleSettings}

--- a/controls-panel.ts
+++ b/controls-panel.ts
@@ -1,6 +1,6 @@
 import { css, html, LitElement } from "lit";
-import "./energy-bar";
 import { customElement, property } from "lit/decorators.js";
+import "./tts-energy-bar";
 
 @customElement("controls-panel")
 export class ControlsPanel extends LitElement {
@@ -168,6 +168,7 @@ export class ControlsPanel extends LitElement {
       </div>
 
       <div class="right-controls">
+        <tts-energy-bar></tts-energy-bar>
         <button
           id="settingsButton"
           @click=${this._toggleSettings}

--- a/controls-panel.ts
+++ b/controls-panel.ts
@@ -1,14 +1,10 @@
 import { css, html, LitElement } from "lit";
 import { customElement, property } from "lit/decorators.js";
-import "./tts-energy-bar";
 
 @customElement("controls-panel")
 export class ControlsPanel extends LitElement {
   @property({ type: Boolean })
   isCallActive = false;
-
-  @property({ type: Boolean })
-  isChatActive = false;
 
   @property({ type: Boolean })
   showCallScrollToBottom = false;
@@ -171,7 +167,6 @@ export class ControlsPanel extends LitElement {
       </div>
 
       <div class="right-controls">
-        ${!this.isChatActive ? html`<tts-energy-bar></tts-energy-bar>` : ""}
         <button
           id="settingsButton"
           @click=${this._toggleSettings}

--- a/index.tsx
+++ b/index.tsx
@@ -408,6 +408,7 @@ export class GdmLiveAudio extends LitElement {
   // Scroll-to-bottom state for chat view
   @state() private showChatScrollToBottom = false;
   @state() private chatNewMessageCount = 0;
+  @state() private isChatActive = false;
 
   // Audio nodes for each session type
   private textOutputNode = this.outputAudioContext.createGain();
@@ -1183,6 +1184,10 @@ export class GdmLiveAudio extends LitElement {
     this.chatNewMessageCount = newMessageCount;
   }
 
+  private _handleChatActiveChanged(e: CustomEvent) {
+    this.isChatActive = e.detail.isChatActive;
+  }
+
   private async _handleSendMessage(e: CustomEvent) {
     const message = e.detail;
     if (!message || !message.trim()) {
@@ -1326,6 +1331,7 @@ export class GdmLiveAudio extends LitElement {
                     @send-message=${this._handleSendMessage}
                     @reset-text=${this._resetTextContext}
                     @scroll-state-changed=${this._handleChatScrollStateChanged}
+                    @chat-active-changed=${this._handleChatActiveChanged}
                   >
                   </chat-view>
                 `
@@ -1357,6 +1363,7 @@ export class GdmLiveAudio extends LitElement {
           }
           <controls-panel
             .isCallActive=${this.isCallActive}
+            .isChatActive=${this.isChatActive}
             .showCallScrollToBottom=${this.showCallScrollToBottom}
             .callNewMessageCount=${this.callNewMessageCount}
             .showChatScrollToBottom=${this.showChatScrollToBottom}

--- a/index.tsx
+++ b/index.tsx
@@ -1266,11 +1266,6 @@ export class GdmLiveAudio extends LitElement {
     this._triggerInitialTTSGreeting();
   }
 
-  protected firstUpdated() {
-    // Trigger initial TTS greeting once the UI is ready
-    this._triggerInitialTTSGreeting();
-  }
-
   private _onEnergyLevelChanged = (e: Event) => {
     const { level, reason, mode } = (e as CustomEvent<EnergyLevelChangedDetail>)
       .detail;

--- a/index.tsx
+++ b/index.tsx
@@ -504,10 +504,7 @@ export class GdmLiveAudio extends LitElement {
       model: energyBarService.getCurrentModel("tts")
     });
     
-    // Trigger initial TTS greeting after a short delay to ensure UI is ready
-    setTimeout(() => {
-      this._triggerInitialTTSGreeting();
-    }, 1000);
+    // Initial TTS greeting is now triggered in firstUpdated
   }
 
   private _triggerInitialTTSGreeting() {
@@ -951,7 +948,7 @@ export class GdmLiveAudio extends LitElement {
     globalToast?.show(this._getApiKeyPrompt(), 'info', 4000, { position: 'top-right' });
   }
 
-  private _handleApiKeySaved() {
+  private async _handleApiKeySaved() {
     // Show success toast for API key saved
     const globalToast = this.shadowRoot?.querySelector('#global-toast') as ToastNotification;
     globalToast?.show("API key saved successfully! ✨", "success", 2500, { position: "top-right" });
@@ -959,7 +956,7 @@ export class GdmLiveAudio extends LitElement {
     logger.info("API key saved, reinitializing client");
 
     // Reinitialize the client with the new API key
-    this.initClient();
+    await this.initClient();
 
     // Close settings menu and toast when API key is saved
     this.showSettings = false;
@@ -969,12 +966,8 @@ export class GdmLiveAudio extends LitElement {
       const action = this.pendingAction;
       this.pendingAction = null; // Clear the pending action
 
-      // Execute the action after a brief delay to ensure client is initialized
-      // The 100ms delay allows the client initialization to complete before
-      // attempting to use the new API key for the pending action
-      setTimeout(() => {
-        action();
-      }, 100);
+      // Execute the action now that the client is initialized
+      action();
     }
   }
 
@@ -1266,6 +1259,16 @@ export class GdmLiveAudio extends LitElement {
       "persona-changed",
       this._handlePersonaChanged.bind(this),
     );
+  }
+
+  protected firstUpdated() {
+    // Trigger initial TTS greeting once the UI is ready
+    this._triggerInitialTTSGreeting();
+  }
+
+  protected firstUpdated() {
+    // Trigger initial TTS greeting once the UI is ready
+    this._triggerInitialTTSGreeting();
   }
 
   private _onEnergyLevelChanged = (e: Event) => {

--- a/index.tsx
+++ b/index.tsx
@@ -1287,8 +1287,8 @@ export class GdmLiveAudio extends LitElement {
       if (prompt && mode === "sts") {
         this._appendCallNotice(prompt);
         logger.debug(`Appended STS call notice`, { prompt });
-      } else if (prompt && mode === "tts") {
-        // All TTS prompts: inject directly into chat window
+      } else if (prompt && mode === "tts" && level < 2) {
+        // Only inject prompts for degraded/exhausted states.
         this._appendTextMessage(prompt, "model");
         logger.debug(`Appended TTS text message`, { prompt });
       }

--- a/src/energy-bar-service.test.ts
+++ b/src/energy-bar-service.test.ts
@@ -3,34 +3,91 @@ import { energyBarService } from "./energy-bar-service";
 
 describe("EnergyBarService", () => {
   beforeEach(() => {
-    // Reset to full before every test
-    energyBarService.setEnergyLevel(3, "manual");
+    // Reset to full before every test for both modes
+    energyBarService.setEnergyLevel(3, "manual", "sts");
+    energyBarService.setEnergyLevel(2, "manual", "tts");
   });
 
-  it("initializes at level 3 with correct model", () => {
-    const level = energyBarService.getCurrentEnergyLevel();
-    expect(level).to.equal(3);
-    expect(energyBarService.getCurrentModel()).to.equal(
-      "gemini-2.5-flash-exp-native-audio-thinking-dialog",
-    );
+  describe("STS Mode", () => {
+    it("initializes at level 3 with correct model", () => {
+      const level = energyBarService.getCurrentEnergyLevel("sts");
+      expect(level).to.equal(3);
+      expect(energyBarService.getCurrentModel("sts")).to.equal(
+        "gemini-2.5-flash-exp-native-audio-thinking-dialog",
+      );
+    });
+
+    it("decrements on handleRateLimitError down to 0", () => {
+      energyBarService.handleRateLimitError("sts"); // 3 -> 2
+      expect(energyBarService.getCurrentEnergyLevel("sts")).to.equal(2);
+      energyBarService.handleRateLimitError("sts"); // 2 -> 1
+      expect(energyBarService.getCurrentEnergyLevel("sts")).to.equal(1);
+      energyBarService.handleRateLimitError("sts"); // 1 -> 0
+      expect(energyBarService.getCurrentEnergyLevel("sts")).to.equal(0);
+      // No negative
+      energyBarService.handleRateLimitError("sts"); // 0 -> 0
+      expect(energyBarService.getCurrentEnergyLevel("sts")).to.equal(0);
+    });
+
+    it("resets to 3 on session-reset", () => {
+      energyBarService.setEnergyLevel(0, "manual", "sts");
+      energyBarService.resetEnergyLevel("session-reset", "sts");
+      expect(energyBarService.getCurrentEnergyLevel("sts")).to.equal(3);
+    });
   });
 
-  it("decrements on handleRateLimitError down to 0", () => {
-    energyBarService.handleRateLimitError(); // 3 -> 2
-    expect(energyBarService.getCurrentEnergyLevel()).to.equal(2);
-    energyBarService.handleRateLimitError(); // 2 -> 1
-    expect(energyBarService.getCurrentEnergyLevel()).to.equal(1);
-    energyBarService.handleRateLimitError(); // 1 -> 0
-    expect(energyBarService.getCurrentEnergyLevel()).to.equal(0);
-    // No negative
-    energyBarService.handleRateLimitError(); // 0 -> 0
-    expect(energyBarService.getCurrentEnergyLevel()).to.equal(0);
+  describe("TTS Mode", () => {
+    it("initializes at level 2 with correct model", () => {
+      const level = energyBarService.getCurrentEnergyLevel("tts");
+      expect(level).to.equal(2);
+      expect(energyBarService.getCurrentModel("tts")).to.equal(
+        "gemini-live-2.5-flash-preview",
+      );
+    });
+
+    it("decrements on handleRateLimitError down to 0", () => {
+      energyBarService.handleRateLimitError("tts"); // 2 -> 1
+      expect(energyBarService.getCurrentEnergyLevel("tts")).to.equal(1);
+      expect(energyBarService.getCurrentModel("tts")).to.equal(
+        "gemini-2.0-flash-live-001", // Fallback model
+      );
+      energyBarService.handleRateLimitError("tts"); // 1 -> 0
+      expect(energyBarService.getCurrentEnergyLevel("tts")).to.equal(0);
+      expect(energyBarService.getCurrentModel("tts")).to.equal(null);
+      // No negative
+      energyBarService.handleRateLimitError("tts"); // 0 -> 0
+      expect(energyBarService.getCurrentEnergyLevel("tts")).to.equal(0);
+    });
+
+    it("resets to 2 on session-reset", () => {
+      energyBarService.setEnergyLevel(0, "manual", "tts");
+      energyBarService.resetEnergyLevel("session-reset", "tts");
+      expect(energyBarService.getCurrentEnergyLevel("tts")).to.equal(2);
+    });
+
+    it("cannot be set above level 2", () => {
+      energyBarService.setEnergyLevel(3, "manual", "tts");
+      expect(energyBarService.getCurrentEnergyLevel("tts")).to.equal(2);
+    });
   });
 
-  it("resets to 3 on session-reset", () => {
-    energyBarService.setEnergyLevel(0, "manual");
-    energyBarService.resetEnergyLevel("session-reset");
-    expect(energyBarService.getCurrentEnergyLevel()).to.equal(3);
+  describe("Mode Independence", () => {
+    it("STS and TTS energy levels are independent", () => {
+      // Drain STS energy
+      energyBarService.handleRateLimitError("sts"); // 3 -> 2
+      energyBarService.handleRateLimitError("sts"); // 2 -> 1
+      
+      // TTS should remain at 2
+      expect(energyBarService.getCurrentEnergyLevel("sts")).to.equal(1);
+      expect(energyBarService.getCurrentEnergyLevel("tts")).to.equal(2);
+      
+      // Drain TTS energy
+      energyBarService.handleRateLimitError("tts"); // 2 -> 1
+      
+      // STS should remain at 1
+      expect(energyBarService.getCurrentEnergyLevel("sts")).to.equal(1);
+      expect(energyBarService.getCurrentEnergyLevel("tts")).to.equal(1);
+    });
   });
 
   it("emits energy-level-changed with detail", async () => {
@@ -46,12 +103,13 @@ describe("EnergyBarService", () => {
         "energy-level-changed",
         handler as EventListener,
       );
-      energyBarService.handleRateLimitError();
+      energyBarService.handleRateLimitError("sts");
     });
 
     expect(ev.detail).to.have.property("prevLevel", 3);
     expect(ev.detail).to.have.property("level", 2);
     expect(ev.detail).to.have.property("reason", "rate-limit-exceeded");
+    expect(ev.detail).to.have.property("mode", "sts");
     expect(ev.detail).to.have.property("modelTier").that.is.a("string");
   });
 });

--- a/src/persona-manager.energy-prompts.test.ts
+++ b/src/persona-manager.energy-prompts.test.ts
@@ -4,24 +4,77 @@ import { PersonaManager } from "./persona-manager";
 describe("PersonaManager.getPromptForEnergyLevel", () => {
   const pm = new PersonaManager();
 
-  it("returns empty string for level 3 (full energy)", () => {
-    expect(pm.getPromptForEnergyLevel(3, "VTuber")).to.equal("");
-    expect(pm.getPromptForEnergyLevel(3, "Assistant")).to.equal("");
-    expect(pm.getPromptForEnergyLevel(3, "Generic")).to.equal("");
+  describe("STS Mode (Voice Calls)", () => {
+    it("returns empty string for level 3 (full energy)", () => {
+      expect(pm.getPromptForEnergyLevel(3, "VTuber", "sts")).to.equal("");
+      expect(pm.getPromptForEnergyLevel(3, "Assistant", "sts")).to.equal("");
+      expect(pm.getPromptForEnergyLevel(3, "Generic", "sts")).to.equal("");
+    });
+
+    it("returns VTuber prompt for medium energy (2)", () => {
+      const text = pm.getPromptForEnergyLevel(2, "VTuber", "sts");
+      expect(text).to.contain("brainpower");
+    });
+
+    it("returns Assistant prompt for low energy (1)", () => {
+      const text = pm.getPromptForEnergyLevel(1, "Assistant", "sts");
+      expect(text).to.contain("processing power is limited");
+    });
+
+    it("returns Generic prompt for exhausted (0)", () => {
+      const text = pm.getPromptForEnergyLevel(0, "Generic", "sts");
+      expect(text.toLowerCase()).to.contain("out of energy");
+    });
   });
 
-  it("returns VTuber prompt for medium energy (2)", () => {
-    const text = pm.getPromptForEnergyLevel(2, "VTuber");
-    expect(text).to.contain("little tired");
+  describe("TTS Mode (Text Chat)", () => {
+    it("returns empty string for level 3 (full energy)", () => {
+      expect(pm.getPromptForEnergyLevel(3, "VTuber", "tts")).to.equal("");
+      expect(pm.getPromptForEnergyLevel(3, "Assistant", "tts")).to.equal("");
+      expect(pm.getPromptForEnergyLevel(3, "Generic", "tts")).to.equal("");
+    });
+
+    it("returns VTuber greeting for level 2", () => {
+      const text = pm.getPromptForEnergyLevel(2, "VTuber", "tts");
+      expect(text).to.contain("Gemini-chan");
+      expect(text).to.contain("excited to chat");
+    });
+
+    it("returns Assistant greeting for level 2", () => {
+      const text = pm.getPromptForEnergyLevel(2, "Assistant", "tts");
+      expect(text).to.contain("Gemini-san");
+      expect(text).to.contain("professional assistant");
+    });
+
+    it("returns VTuber degraded prompt for level 1", () => {
+      const text = pm.getPromptForEnergyLevel(1, "VTuber", "tts");
+      expect(text).to.contain("sleepy");
+      expect(text).to.contain("simpler");
+    });
+
+    it("returns Assistant degraded prompt for level 1", () => {
+      const text = pm.getPromptForEnergyLevel(1, "Assistant", "tts");
+      expect(text).to.contain("reduced capabilities");
+    });
+
+    it("returns VTuber exhausted prompt for level 0", () => {
+      const text = pm.getPromptForEnergyLevel(0, "VTuber", "tts");
+      expect(text).to.contain("tired");
+      expect(text).to.contain("rest");
+    });
+
+    it("returns Assistant exhausted prompt for level 0", () => {
+      const text = pm.getPromptForEnergyLevel(0, "Assistant", "tts");
+      expect(text).to.contain("offline");
+      expect(text).to.contain("maintenance");
+    });
   });
 
-  it("returns Assistant prompt for low energy (1)", () => {
-    const text = pm.getPromptForEnergyLevel(1, "Assistant");
-    expect(text).to.contain("processing power is limited");
-  });
-
-  it("returns Generic prompt for exhausted (0)", () => {
-    const text = pm.getPromptForEnergyLevel(0, "Generic");
-    expect(text.toLowerCase()).to.contain("out of energy");
+  describe("Backward Compatibility", () => {
+    it("defaults to STS mode when mode is not specified", () => {
+      const stsText = pm.getPromptForEnergyLevel(2, "VTuber", "sts");
+      const defaultText = pm.getPromptForEnergyLevel(2, "VTuber");
+      expect(defaultText).to.equal(stsText);
+    });
   });
 });

--- a/src/persona-manager.ts
+++ b/src/persona-manager.ts
@@ -25,67 +25,68 @@ export class PersonaManager {
     mode: "sts" | "tts" = "sts",
   ): string {
     if (level >= 3) return ""; // No special prompt for full energy
+
+    const prompts = {
+      sts: {
+        2: {
+          vtuber:
+            "I might be running a tiny bit low on brainpower—so if I trail off or keep things simpler, forgive me! I’ll still give it my all, promise~",
+          assistant:
+            "System capacity is reduced. I can still help effectively, but responses may be more concise.",
+          default:
+            "Energy reduced. I can continue, but responses may be simpler for now.",
+        },
+        1: {
+          assistant:
+            "My processing power is limited at the moment. I can still assist with basic tasks.",
+          vtuber:
+            "Mm... my emotional scanner’s flickering... I can still hear you just fine and respond, but my feelings might sound a little sleepy...",
+          default: "Low energy. I can help with basic requests only.",
+        },
+        0: {
+          assistant:
+            "My systems just powered down to protect my core. I’ll need a moment to recharge—please try again in a bit.",
+          vtuber:
+            "N-nngh... I’m out of juice... My consciousness is drifting... I’ll nap for a bit and come back brighter, o-okay? (｡•́︿•̀｡)",
+          default:
+            "I'm sorry, I'm out of energy and need to rest. Please try again later.",
+        },
+      },
+      tts: {
+        2: {
+          vtuber:
+            "Hey there! ✨ I'm Gemini-chan, and I'm super excited to chat with you! What's on your mind today? I'd love to hear about anything you want to talk about~",
+          assistant:
+            "Hello! I'm Gemini-san, your professional assistant. I'm ready to help you with any questions or tasks you might have. Please feel free to share what you need assistance with.",
+          default:
+            "Hello! I'm ready to chat with you. What would you like to talk about today?",
+        },
+        1: {
+          vtuber:
+            "Mm... I'm feeling a bit sleepy, but I'm still here for you! My responses might be a little simpler than usual, but let's chat anyway~ (´∀｀)",
+          assistant:
+            "I'm operating with reduced capabilities at the moment, but I can still assist you with basic inquiries and tasks.",
+          default:
+            "I'm running on reduced power, but I'm still here to help with simpler requests.",
+        },
+        0: {
+          vtuber:
+            "Zzz... I'm too tired to chat right now... (｡-ω-｡) Please let me rest for a bit and try again later, okay?",
+          assistant:
+            "My systems are currently offline for maintenance. Please try again later when I've had time to recharge.",
+          default:
+            "I'm currently out of energy and need to rest. Please try again later.",
+        },
+      },
+    };
+
     const name = (personaName || "").toLowerCase();
-    // STS immersive prompts per spec
-    if (mode === "sts" && level === 2) {
-      if (name === "vtuber") {
-        return "I might be running a tiny bit low on brainpower—so if I trail off or keep things simpler, forgive me! I’ll still give it my all, promise~";
-      }
-      if (name === "assistant") {
-        return "System capacity is reduced. I can still help effectively, but responses may be more concise.";
-      }
-      return "Energy reduced. I can continue, but responses may be simpler for now.";
-    }
-    if (mode === "sts" && level === 1) {
-      if (name === "assistant") {
-        return "My processing power is limited at the moment. I can still assist with basic tasks.";
-      }
-      if (name === "vtuber") {
-        return "Mm... my emotional scanner’s flickering... I can still hear you just fine and respond, but my feelings might sound a little sleepy...";
-      }
-      return "Low energy. I can help with basic requests only.";
-    }
-    // STS exhausted
-    if (mode === "sts" && level === 0) {
-      if (name === "assistant") {
-        return "My systems just powered down to protect my core. I’ll need a moment to recharge—please try again in a bit.";
-      }
-      if (name === "vtuber") {
-        return "N-nngh... I’m out of juice... My consciousness is drifting... I’ll nap for a bit and come back brighter, o-okay? (｡•́︿•̀｡)";
-      }
-      return "I'm sorry, I'm out of energy and need to rest. Please try again later.";
+    const promptSet = prompts[mode]?.[level as 0 | 1 | 2];
+
+    if (promptSet) {
+      return promptSet[name as keyof typeof promptSet] || promptSet.default;
     }
 
-    // TTS immersive prompts for chat
-    if (mode === "tts" && level === 2) {
-      if (name === "vtuber") {
-        return "Hey there! ✨ I'm Gemini-chan, and I'm super excited to chat with you! What's on your mind today? I'd love to hear about anything you want to talk about~";
-      }
-      if (name === "assistant") {
-        return "Hello! I'm Gemini-san, your professional assistant. I'm ready to help you with any questions or tasks you might have. Please feel free to share what you need assistance with.";
-      }
-      return "Hello! I'm ready to chat with you. What would you like to talk about today?";
-    }
-    if (mode === "tts" && level === 1) {
-      if (name === "vtuber") {
-        return "Mm... I'm feeling a bit sleepy, but I'm still here for you! My responses might be a little simpler than usual, but let's chat anyway~ (´∀｀)";
-      }
-      if (name === "assistant") {
-        return "I'm operating with reduced capabilities at the moment, but I can still assist you with basic inquiries and tasks.";
-      }
-      return "I'm running on reduced power, but I'm still here to help with simpler requests.";
-    }
-    if (mode === "tts" && level === 0) {
-      if (name === "vtuber") {
-        return "Zzz... I'm too tired to chat right now... (｡-ω-｡) Please let me rest for a bit and try again later, okay?";
-      }
-      if (name === "assistant") {
-        return "My systems are currently offline for maintenance. Please try again later when I've had time to recharge.";
-      }
-      return "I'm currently out of energy and need to rest. Please try again later.";
-    }
-
-    // Default: no prompt for other modes yet
     return "";
   }
 

--- a/src/persona-manager.ts
+++ b/src/persona-manager.ts
@@ -56,6 +56,35 @@ export class PersonaManager {
       return "I'm sorry, I'm out of energy and need to rest. Please try again later.";
     }
 
+    // TTS immersive prompts for chat
+    if (mode === "tts" && level === 2) {
+      if (name === "vtuber") {
+        return "Hey there! ✨ I'm Gemini-chan, and I'm super excited to chat with you! What's on your mind today? I'd love to hear about anything you want to talk about~";
+      }
+      if (name === "assistant") {
+        return "Hello! I'm Gemini-san, your professional assistant. I'm ready to help you with any questions or tasks you might have. Please feel free to share what you need assistance with.";
+      }
+      return "Hello! I'm ready to chat with you. What would you like to talk about today?";
+    }
+    if (mode === "tts" && level === 1) {
+      if (name === "vtuber") {
+        return "Mm... I'm feeling a bit sleepy, but I'm still here for you! My responses might be a little simpler than usual, but let's chat anyway~ (´∀｀)";
+      }
+      if (name === "assistant") {
+        return "I'm operating with reduced capabilities at the moment, but I can still assist you with basic inquiries and tasks.";
+      }
+      return "I'm running on reduced power, but I'm still here to help with simpler requests.";
+    }
+    if (mode === "tts" && level === 0) {
+      if (name === "vtuber") {
+        return "Zzz... I'm too tired to chat right now... (｡-ω-｡) Please let me rest for a bit and try again later, okay?";
+      }
+      if (name === "assistant") {
+        return "My systems are currently offline for maintenance. Please try again later when I've had time to recharge.";
+      }
+      return "I'm currently out of energy and need to rest. Please try again later.";
+    }
+
     // Default: no prompt for other modes yet
     return "";
   }

--- a/tab-view.ts
+++ b/tab-view.ts
@@ -1,5 +1,6 @@
 import { css, html, LitElement } from "lit";
 import { customElement, property } from "lit/decorators.js";
+import "./tts-energy-bar";
 
 @customElement("tab-view")
 export class TabView extends LitElement {
@@ -8,6 +9,8 @@ export class TabView extends LitElement {
   static styles = css`
     .tabs {
       display: flex;
+      justify-content: space-between;
+      align-items: center;
       gap: 8px;
       padding: 8px 12px;
       border-bottom: 1px solid var(--cp-surface-border);
@@ -15,6 +18,17 @@ export class TabView extends LitElement {
       position: sticky;
       top: 0;
       z-index: 5;
+    }
+    
+    .tab-buttons {
+      display: flex;
+      gap: 8px;
+    }
+    
+    .tab-indicators {
+      display: flex;
+      align-items: center;
+      gap: 8px;
     }
     .tab {
       padding: 10px 16px;
@@ -53,17 +67,22 @@ export class TabView extends LitElement {
   render() {
     return html`
       <div class="tabs">
-        <div
-          class="tab ${this.activeTab === "chat" ? "active" : ""}"
-          @click=${() => this._switchTab("chat")}
-        >
-          Chat
+        <div class="tab-buttons">
+          <div
+            class="tab ${this.activeTab === "chat" ? "active" : ""}"
+            @click=${() => this._switchTab("chat")}
+          >
+            Chat
+          </div>
+          <div
+            class="tab ${this.activeTab === "call-history" ? "active" : ""}"
+            @click=${() => this._switchTab("call-history")}
+          >
+            Call History
+          </div>
         </div>
-        <div
-          class="tab ${this.activeTab === "call-history" ? "active" : ""}"
-          @click=${() => this._switchTab("call-history")}
-        >
-          Call History
+        <div class="tab-indicators">
+          <tts-energy-bar></tts-energy-bar>
         </div>
       </div>
     `;

--- a/tab-view.ts
+++ b/tab-view.ts
@@ -5,8 +5,18 @@ import "./tts-energy-bar";
 @customElement("tab-view")
 export class TabView extends LitElement {
   @property({ type: String }) activeTab: "chat" | "call-history" = "chat";
+  @property({ type: Boolean, reflect: true }) visible: boolean = true;
 
   static styles = css`
+    :host {
+      display: none;
+      transition: opacity 0.3s ease, visibility 0.3s ease;
+    }
+
+    :host([visible]) {
+      display: block;
+    }
+
     .tabs {
       display: flex;
       justify-content: space-between;

--- a/test-energy-bar-changes.js
+++ b/test-energy-bar-changes.js
@@ -1,0 +1,35 @@
+// Quick test to verify the energy bar changes work correctly
+import { energyBarService } from './src/energy-bar-service.js';
+
+console.log('Testing Energy Bar Service Changes...\n');
+
+// Test initial states
+console.log('Initial States:');
+console.log(`STS Energy Level: ${energyBarService.getCurrentEnergyLevel('sts')}`);
+console.log(`STS Model: ${energyBarService.getCurrentModel('sts')}`);
+console.log(`TTS Energy Level: ${energyBarService.getCurrentEnergyLevel('tts')}`);
+console.log(`TTS Model: ${energyBarService.getCurrentModel('tts')}\n`);
+
+// Test TTS fallback model at level 1
+console.log('Testing TTS fallback model...');
+energyBarService.handleRateLimitError('tts'); // 2 -> 1
+console.log(`TTS Energy Level after rate limit: ${energyBarService.getCurrentEnergyLevel('tts')}`);
+console.log(`TTS Model after rate limit: ${energyBarService.getCurrentModel('tts')}`);
+
+// Test that STS is unaffected
+console.log(`STS Energy Level (should be unchanged): ${energyBarService.getCurrentEnergyLevel('sts')}`);
+console.log(`STS Model (should be unchanged): ${energyBarService.getCurrentModel('sts')}\n`);
+
+// Test TTS reset to max level 2
+console.log('Testing TTS reset...');
+energyBarService.resetEnergyLevel('session-reset', 'tts');
+console.log(`TTS Energy Level after reset: ${energyBarService.getCurrentEnergyLevel('tts')}`);
+console.log(`TTS Model after reset: ${energyBarService.getCurrentModel('tts')}\n`);
+
+// Test TTS cannot go above level 2
+console.log('Testing TTS max level constraint...');
+energyBarService.setEnergyLevel(3, 'manual', 'tts');
+console.log(`TTS Energy Level after trying to set to 3: ${energyBarService.getCurrentEnergyLevel('tts')}`);
+console.log(`TTS Model: ${energyBarService.getCurrentModel('tts')}\n`);
+
+console.log('All tests completed!');

--- a/test-tts-prompt-injection-debug.js
+++ b/test-tts-prompt-injection-debug.js
@@ -1,0 +1,36 @@
+// Debug test to verify TTS prompt injection
+import { PersonaManager } from './src/persona-manager.js';
+import { energyBarService } from './src/energy-bar-service.js';
+
+console.log('=== TTS Prompt Injection Debug Test ===\n');
+
+const personaManager = new PersonaManager();
+
+// Test the persona manager directly
+console.log('1. Testing PersonaManager directly:');
+const vtuberGreeting = personaManager.getPromptForEnergyLevel(2, 'VTuber', 'tts');
+console.log(`VTuber Level 2 TTS Prompt: "${vtuberGreeting}"`);
+
+const assistantGreeting = personaManager.getPromptForEnergyLevel(2, 'Assistant', 'tts');
+console.log(`Assistant Level 2 TTS Prompt: "${assistantGreeting}"`);
+
+// Test energy service state
+console.log('\n2. Testing EnergyBarService state:');
+console.log(`Current TTS Energy Level: ${energyBarService.getCurrentEnergyLevel('tts')}`);
+console.log(`Current TTS Model: ${energyBarService.getCurrentModel('tts')}`);
+
+// Test energy level change events
+console.log('\n3. Testing energy level change events:');
+energyBarService.addEventListener('energy-level-changed', (e) => {
+  console.log(`Energy change event fired:`, e.detail);
+});
+
+// Simulate a TTS energy change to trigger the event
+console.log('Simulating TTS energy change...');
+energyBarService.handleRateLimitError('tts');
+
+// Reset back to level 2
+console.log('Resetting TTS energy...');
+energyBarService.resetEnergyLevel('session-reset', 'tts');
+
+console.log('\n=== Debug Test Complete ===');

--- a/test-tts-prompt-injection.js
+++ b/test-tts-prompt-injection.js
@@ -1,0 +1,57 @@
+// Test to verify TTS prompt injection works correctly
+import { PersonaManager } from './src/persona-manager.js';
+import { energyBarService } from './src/energy-bar-service.js';
+
+console.log('Testing TTS Prompt Injection...\n');
+
+const personaManager = new PersonaManager();
+
+// Test VTuber persona TTS prompts
+console.log('=== VTuber Persona TTS Prompts ===');
+console.log('Level 2 (Greeting):', personaManager.getPromptForEnergyLevel(2, 'VTuber', 'tts'));
+console.log('Level 1 (Degraded):', personaManager.getPromptForEnergyLevel(1, 'VTuber', 'tts'));
+console.log('Level 0 (Exhausted):', personaManager.getPromptForEnergyLevel(0, 'VTuber', 'tts'));
+
+console.log('\n=== Assistant Persona TTS Prompts ===');
+console.log('Level 2 (Greeting):', personaManager.getPromptForEnergyLevel(2, 'Assistant', 'tts'));
+console.log('Level 1 (Degraded):', personaManager.getPromptForEnergyLevel(1, 'Assistant', 'tts'));
+console.log('Level 0 (Exhausted):', personaManager.getPromptForEnergyLevel(0, 'Assistant', 'tts'));
+
+console.log('\n=== Generic Persona TTS Prompts ===');
+console.log('Level 2 (Greeting):', personaManager.getPromptForEnergyLevel(2, 'Generic', 'tts'));
+console.log('Level 1 (Degraded):', personaManager.getPromptForEnergyLevel(1, 'Generic', 'tts'));
+console.log('Level 0 (Exhausted):', personaManager.getPromptForEnergyLevel(0, 'Generic', 'tts'));
+
+console.log('\n=== Energy Service TTS State ===');
+console.log(`Current TTS Energy Level: ${energyBarService.getCurrentEnergyLevel('tts')}`);
+console.log(`Current TTS Model: ${energyBarService.getCurrentModel('tts')}`);
+
+console.log('\n=== Testing TTS Energy Level Changes ===');
+console.log('All TTS prompts should be injected into the chat window:');
+console.log('- Level 2: Welcoming greetings to encourage interaction');
+console.log('- Level 1: Degraded state messages explaining reduced capability');
+console.log('- Level 0: Exhausted state messages explaining unavailability');
+
+// Simulate TTS rate limit to trigger level 1 prompt
+console.log('\nSimulating TTS rate limit (2 -> 1)...');
+energyBarService.handleRateLimitError('tts');
+console.log(`New TTS Energy Level: ${energyBarService.getCurrentEnergyLevel('tts')}`);
+console.log(`New TTS Model: ${energyBarService.getCurrentModel('tts')}`);
+console.log(`Level 1 prompt would be injected: "${personaManager.getPromptForEnergyLevel(1, 'VTuber', 'tts')}"`);
+
+// Simulate another rate limit to trigger level 0 prompt
+console.log('\nSimulating another TTS rate limit (1 -> 0)...');
+energyBarService.handleRateLimitError('tts');
+console.log(`New TTS Energy Level: ${energyBarService.getCurrentEnergyLevel('tts')}`);
+console.log(`New TTS Model: ${energyBarService.getCurrentModel('tts')}`);
+console.log(`Level 0 prompt would be injected: "${personaManager.getPromptForEnergyLevel(0, 'VTuber', 'tts')}"`);
+
+// Reset to level 2
+console.log('\nResetting TTS energy...');
+energyBarService.resetEnergyLevel('session-reset', 'tts');
+console.log(`Reset TTS Energy Level: ${energyBarService.getCurrentEnergyLevel('tts')}`);
+console.log(`Reset TTS Model: ${energyBarService.getCurrentModel('tts')}`);
+console.log(`Level 2 greeting would be injected: "${personaManager.getPromptForEnergyLevel(2, 'VTuber', 'tts')}"`);
+
+console.log('\n✅ TTS prompt injection test completed!');
+console.log('All TTS prompts are now injected directly into the chat window where they belong.');

--- a/toast-notification.ts
+++ b/toast-notification.ts
@@ -23,6 +23,8 @@ export class ToastNotification extends LitElement {
   @state()
   private _isAnimating = false;
 
+  private hideTimeout?: ReturnType<typeof setTimeout>;
+
   static styles = css`
     :host {
       /* Theming hooks */
@@ -136,6 +138,9 @@ export class ToastNotification extends LitElement {
     duration: number = 0,
     opts?: { position?: "top-center" | "bottom-center" | "top-right" | "bottom-right"; variant?: "standard" | "inline" }
   ) {
+    if (this.hideTimeout) {
+      clearTimeout(this.hideTimeout);
+    }
     this.message = message;
     this.type = type;
     if (opts?.position) this.position = opts.position;
@@ -144,7 +149,7 @@ export class ToastNotification extends LitElement {
     this._isAnimating = true;
 
     if (duration > 0) {
-      setTimeout(() => this.hide(), duration);
+      this.hideTimeout = setTimeout(() => this.hide(), duration);
     }
 
     this.dispatchEvent(new CustomEvent("toast-show", {

--- a/toast-notification.ts
+++ b/toast-notification.ts
@@ -165,6 +165,7 @@ export class ToastNotification extends LitElement {
     setTimeout(() => {
       this.message = "";
       this._isAnimating = false;
+      this.hideTimeout = undefined;
     }, 300);
     this.dispatchEvent(new CustomEvent("toast-hide", { bubbles: true, composed: true }));
   }

--- a/toast-notification.ts
+++ b/toast-notification.ts
@@ -12,34 +12,75 @@ export class ToastNotification extends LitElement {
   @property({ type: String })
   type: "info" | "success" | "warning" | "error" = "info";
 
+  // Screen position for the toast
+  @property({ type: String, reflect: true })
+  position: "top-center" | "bottom-center" | "top-right" | "bottom-right" = "top-center";
+
+  // Visual variant (inline = lighter surface, used over Live2D center bottom)
+  @property({ type: String, reflect: true })
+  variant: "standard" | "inline" = "standard";
+
   @state()
   private _isAnimating = false;
 
   static styles = css`
     :host {
+      /* Theming hooks */
+      --toast-bg: var(--cp-surface);
+      --toast-bg-strong: var(--cp-surface-strong);
+      --toast-border: var(--cp-surface-border);
+      --toast-text: var(--cp-text);
+      --toast-shadow-info: var(--cp-glow-cyan);
+      --toast-shadow-warn: var(--cp-glow-magenta);
+
       position: fixed;
-      top: 24px;
-      left: 50%;
-      transform: translateX(-50%);
-      z-index: 50;
+      z-index: 60;
       pointer-events: none;
     }
 
+    /* Positions */
+    :host([position="top-center"]) {
+      top: 24px;
+      left: 50%;
+      transform: translateX(-50%);
+    }
+    :host([position="bottom-center"]) {
+      bottom: 24px;
+      left: 50%;
+      transform: translateX(-50%);
+    }
+    :host([position="top-right"]) {
+      top: 24px;
+      right: 24px;
+    }
+    :host([position="bottom-right"]) {
+      bottom: 24px;
+      right: 24px;
+    }
+
     .toast {
-      display: inline-block;
-      padding: 8px 12px;
-      border-radius: 10px;
-      font: 17px/1.2 system-ui;
-      box-shadow: var(--cp-glow-cyan);
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      padding: 10px 14px;
+      border-radius: 12px;
+      font: 15px/1.3 system-ui;
+      color: var(--toast-text);
+      background: var(--toast-bg);
+      border: 1px solid var(--toast-border);
+      box-shadow: var(--toast-shadow-info);
       backdrop-filter: blur(8px);
-      opacity: 0;
-      transform: translateY(-20px);
-      transition: all 300ms cubic-bezier(0.4, 0, 0.2, 1);
-      max-width: 400px;
-      text-align: center;
+      max-width: 520px;
+      text-align: left;
       pointer-events: auto;
-      border: 1px solid var(--cp-surface-border);
-      color: var(--cp-text);
+
+      opacity: 0;
+      transform: translateY(-10px);
+      transition: all 250ms cubic-bezier(0.4, 0, 0.2, 1);
+    }
+
+    :host([position="bottom-center"]) .toast {
+      transform: translateY(10px);
     }
 
     .toast.visible {
@@ -47,48 +88,27 @@ export class ToastNotification extends LitElement {
       transform: translateY(0);
     }
 
-    .toast.info {
-      background: linear-gradient(135deg, var(--cp-cyan), var(--cp-purple));
-      color: #000;
-      font-weight: 600;
+    /* Type accents via glow */
+    .toast.info { box-shadow: var(--toast-shadow-info); }
+    .toast.success { box-shadow: var(--toast-shadow-info); }
+    .toast.warning { box-shadow: var(--toast-shadow-warn); }
+    .toast.error { box-shadow: var(--toast-shadow-warn); }
+
+    /* Inline variant used for bottom-center over Live2D */
+    :host([variant="inline"]) .toast {
+      font: 17px/1.2 system-ui;
+      padding: 8px 12px;
+      border-radius: 10px;
+      background: var(--toast-bg-strong);
+      border: 1px solid var(--toast-border);
     }
 
-    .toast.warning {
-      background: linear-gradient(135deg, var(--cp-amber), var(--cp-red));
-      color: #000;
-      font-weight: 600;
-    }
-
-    .toast.success {
-      background: linear-gradient(135deg, var(--cp-green), var(--cp-cyan));
-      color: #000;
-      font-weight: 600;
-    }
-
-    .toast.error {
-      background: linear-gradient(135deg, var(--cp-red), var(--cp-purple));
-      color: #000;
-      font-weight: 600;
-    }
-
-    .toast-icon {
-      display: inline-block;
-      margin-right: 8px;
-      font-size: 18px;
-      vertical-align: middle;
-    }
-
-    .toast-message {
-      display: inline-block;
-      vertical-align: middle;
-    }
+    .toast-icon { display: inline-block; font-size: 18px; }
+    .toast-message { display: inline-block; }
   `;
 
   render() {
-    if (!this.message) {
-      return html``;
-    }
-
+    if (!this.message) return html``;
     return html`
       <div class="toast ${this.type} ${this.visible ? "visible" : ""}">
         <span class="toast-icon">${this._getIcon()}</span>
@@ -99,85 +119,51 @@ export class ToastNotification extends LitElement {
 
   private _getIcon(): string {
     switch (this.type) {
-      case "info":
-        return "ℹ️";
-      case "success":
-        return "✅";
-      case "warning":
-        return "⚠️";
-      case "error":
-        return "❌";
-      default:
-        return "ℹ️";
+      case "info": return "ℹ️";
+      case "success": return "✅";
+      case "warning": return "⚠️";
+      case "error": return "❌";
+      default: return "ℹ️";
     }
   }
 
   /**
-   * Show the toast with a message
-   * @param message - The message to display
-   * @param type - The type of toast (info, success, warning, error)
-   * @param duration - How long to show the toast in milliseconds (0 = manual hide)
+   * Show the toast with optional overrides
    */
   show(
     message: string,
     type: "info" | "success" | "warning" | "error" = "info",
     duration: number = 0,
+    opts?: { position?: "top-center" | "bottom-center" | "top-right" | "bottom-right"; variant?: "standard" | "inline" }
   ) {
     this.message = message;
     this.type = type;
+    if (opts?.position) this.position = opts.position;
+    if (opts?.variant) this.variant = opts.variant;
     this.visible = true;
     this._isAnimating = true;
 
-    // Auto-hide after duration if specified
     if (duration > 0) {
-      setTimeout(() => {
-        this.hide();
-      }, duration);
+      setTimeout(() => this.hide(), duration);
     }
 
-    // Dispatch show event
-    this.dispatchEvent(
-      new CustomEvent("toast-show", {
-        detail: { message, type },
-        bubbles: true,
-        composed: true,
-      }),
-    );
+    this.dispatchEvent(new CustomEvent("toast-show", {
+      detail: { message, type },
+      bubbles: true,
+      composed: true,
+    }));
   }
 
-  /**
-   * Hide the toast
-   */
   hide() {
     this.visible = false;
     this._isAnimating = true;
-
-    // Clear message after animation completes
     setTimeout(() => {
       this.message = "";
       this._isAnimating = false;
     }, 300);
-
-    // Dispatch hide event
-    this.dispatchEvent(
-      new CustomEvent("toast-hide", {
-        bubbles: true,
-        composed: true,
-      }),
-    );
+    this.dispatchEvent(new CustomEvent("toast-hide", { bubbles: true, composed: true }));
   }
 
-  /**
-   * Check if the toast is currently visible
-   */
-  get isVisible(): boolean {
-    return this.visible;
-  }
-
-  /**
-   * Check if the toast is currently animating
-   */
-  get isAnimating(): boolean {
-    return this._isAnimating;
-  }
+  get isVisible(): boolean { return this.visible; }
+  get isAnimating(): boolean { return this._isAnimating; }
 }

--- a/tts-energy-bar.ts
+++ b/tts-energy-bar.ts
@@ -1,0 +1,166 @@
+import { css, html, LitElement } from "lit";
+import { customElement, property, state } from "lit/decorators.js";
+import {
+  type EnergyLevelChangedDetail,
+  energyBarService,
+  TTSEnergyLevel,
+} from "./src/energy-bar-service";
+
+@customElement("tts-energy-bar")
+export class TTSEnergyBar extends LitElement {
+  @property({ type: Number, reflect: true }) level: 0 | 1 | 2 =
+    energyBarService.getCurrentEnergyLevel("tts") as TTSEnergyLevel;
+
+  @state() private _animating = false;
+  @state() private _changedIndex: number = -1;
+  @state() private _changeKind: "fill" | "drain" | null = null;
+
+  static styles = css`
+    :host { 
+      display: inline-flex; 
+      align-items: center; 
+      gap: 8px; 
+    }
+    
+    .battery { 
+      position: relative; 
+      width: 32px; 
+      height: 16px; 
+      border: 2px solid currentColor; 
+      border-radius: 3px; 
+      box-sizing: border-box; 
+    }
+    
+    .battery::after { 
+      content: ""; 
+      position: absolute; 
+      right: -3px; 
+      top: 3px; 
+      width: 2px; 
+      height: 8px; 
+      background: currentColor; 
+      border-radius: 1px; 
+    }
+    
+    .bars { 
+      display: grid; 
+      grid-template-columns: repeat(2, 1fr); 
+      gap: 2px; 
+      padding: 2px; 
+      height: 100%; 
+    }
+    
+    .bar { 
+      border-radius: 1px; 
+      background: currentColor; 
+      opacity: 0.35; 
+      transition: opacity 200ms ease, transform 200ms ease; 
+    }
+    
+    .bar.filled { 
+      opacity: 1; 
+    }
+    
+    /* TTS-specific colors for 3-level system */
+    :host([level="2"]) { color: #00c853; } /* Green - Full */
+    :host([level="1"]) { color: #fdd835; } /* Yellow - Degraded */
+    :host([level="0"]) { color: #e53935; } /* Red - Exhausted */
+    
+    .bar.drain { 
+      transform: scaleY(0); 
+      opacity: 0.3; 
+    }
+    
+    .bar.fill { 
+      transform: scaleY(1.1); 
+    }
+  `;
+
+  connectedCallback(): void {
+    super.connectedCallback();
+    energyBarService.addEventListener(
+      "energy-level-changed",
+      this._onEnergyChanged as EventListener,
+    );
+  }
+
+  disconnectedCallback(): void {
+    energyBarService.removeEventListener(
+      "energy-level-changed",
+      this._onEnergyChanged as EventListener,
+    );
+    super.disconnectedCallback();
+  }
+
+  private _onEnergyChanged = (e: CustomEvent<EnergyLevelChangedDetail>) => {
+    // Only reflect TTS mode in this bar
+    if (e.detail.mode !== "tts") return;
+
+    const old = this.level;
+    const next = e.detail.level as 0 | 1 | 2;
+    if (old === next) return;
+
+    // Determine which bar changed and the kind of change
+    if (next < old) {
+      this._changedIndex = old - 1; // drained last filled bar
+      this._changeKind = "drain";
+    } else {
+      this._changedIndex = next - 1; // filled next bar
+      this._changeKind = "fill";
+    }
+
+    this._animating = true;
+    this.level = next;
+    // end animation after short delay
+    setTimeout(() => {
+      this._animating = false;
+      this._changedIndex = -1;
+      this._changeKind = null;
+    }, 250);
+  };
+
+  private _energyText(level: 0 | 1 | 2): string {
+    switch (level) {
+      case 2:
+        return "Full";
+      case 1:
+        return "Degraded";
+      default:
+        return "Exhausted";
+    }
+  }
+
+  render() {
+    const filledCount = this.level;
+    const bars = [0, 1].map((i) => i < filledCount);
+    const model = energyBarService.getModelForLevel(this.level, "tts");
+    const ariaValueText = `${this._energyText(this.level)}${model ? ` — ${model}` : ""}`;
+
+    return html`
+      <div
+        class="battery"
+        role="meter"
+        aria-valuemin="0"
+        aria-valuemax="2"
+        aria-valuenow=${String(this.level)}
+        aria-valuetext=${ariaValueText}
+        title=${`Chat Energy: ${this.level}/2 (${this._energyText(this.level)})${model ? ` — ${model}` : ""}`}
+      >
+        <div class="bars">
+          ${bars.map((filled, idx) => {
+            const classes = ["bar"]; // base
+            if (filled) classes.push("filled");
+            if (
+              this._animating &&
+              idx === this._changedIndex &&
+              this._changeKind
+            ) {
+              classes.push(this._changeKind);
+            }
+            return html`<div class=${classes.join(" ")}></div>`;
+          })}
+        </div>
+      </div>
+    `;
+  }
+}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Introduces dual-session energy management with independent STS and TTS indicators, persona-specific prompts, and comprehensive testing.
> 
>   - **Behavior**:
>     - Introduces `EnergyBarService` to manage energy levels for STS and TTS modes, with independent levels and model switching.
>     - Adds TTS energy indicator in `tab-view.ts` and STS indicator in `call-transcript.ts`.
>     - Persona-specific prompts for energy levels in `persona-manager.ts`.
>   - **UI Components**:
>     - `tts-energy-bar.ts` for TTS energy levels (0-2) with animations.
>     - `toast-notification.ts` redesigned for theme integration and persona-aware styling.
>     - `controls-panel.ts` updated for scroll-to-bottom functionality.
>   - **Testing**:
>     - Unit tests in `energy-bar-service.test.ts` for energy level transitions.
>     - Tests for persona prompts in `persona-manager.energy-prompts.test.ts`.
>     - Debug scripts `test-energy-bar-changes.js` and `test-tts-prompt-injection.js` for energy and prompt verification.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=daoch4n%2Fgemini-live-2d&utm_source=github&utm_medium=referral)<sup> for 85fab5294ac16370730935ddf0790a5d0cc45e11. You can [customize](https://app.ellipsis.dev/daoch4n/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->